### PR TITLE
feat: add feature to toggle contrast

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,50 @@
 <template>
-  <div id="app">
-    <router-view/>
+  <div id="app" :class="{ contrast: highContrast }">
+    <div :class="{ invert: highContrast }">
+      <router-view/>
+      <div class="bg" />
+    </div>
+    <button class="btn" @click="toggleContrast()">PENCET GANTI WARNA</button>
   </div>
 </template>
 
-<style>
+<script>
+  import { mapState, mapMutations } from 'vuex'
+  import { TOGGLE_CONSTRAST } from '@/store/global/mutations'
+
+  export default {
+    computed: {
+      ...mapState(['highContrast'])
+    },
+    methods: {
+      ...mapMutations({
+        toggleContrast: TOGGLE_CONSTRAST
+      })
+    }
+  }
+</script>
+
+<style scoped>
+  .contrast {
+    filter: brightness(200%);
+    min-height: 100vh;
+  }
+
+  .invert {
+    filter: invert(100%);
+    min-height: 100vh;
+  }
+
+  .bg {
+    @apply absolute w-full h-full bg-background top-0 left-0;
+    z-index: -1;
+  }
+
+  .btn {
+    position: fixed;
+    bottom: 4rem;
+    left: 4rem;
+    background-color: red;
+    padding: 1rem;
+  }
 </style>

--- a/src/store/global/actions.js
+++ b/src/store/global/actions.js
@@ -1,0 +1,1 @@
+export default {}

--- a/src/store/global/getters.js
+++ b/src/store/global/getters.js
@@ -1,0 +1,1 @@
+export default {}

--- a/src/store/global/mutations.js
+++ b/src/store/global/mutations.js
@@ -1,0 +1,7 @@
+export const TOGGLE_CONSTRAST = 'TOGGLE_CONTRAST'
+
+export default {
+  [TOGGLE_CONSTRAST](state) {
+    state.highContrast = !state.highContrast
+  }
+}

--- a/src/store/global/state.js
+++ b/src/store/global/state.js
@@ -1,0 +1,3 @@
+export default {
+  highContrast: false
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,16 +1,18 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
-import UserCredentials from "./modules/User";
+import UserCredentials from "./modules/User"
+import state from './global/state'
+import getters from './global/getters'
+import mutations from './global/mutations'
+import actions from './global/actions'
 
 Vue.use(Vuex)
 
 export default new Vuex.Store({
-  state: {
-  },
-  mutations: {
-  },
-  actions: {
-  },
+  state,
+  getters,
+  mutations,
+  actions,
   modules: {
     UserCredentials
   }


### PR DESCRIPTION
I have added the feature to toggle screen contrast. (Please ignore the ugly button for the time being.)

![image](https://user-images.githubusercontent.com/48923485/100723708-b2d0d780-33f4-11eb-9756-ba446e764534.png)
Normal mode

![image](https://user-images.githubusercontent.com/48923485/100723733-bbc1a900-33f4-11eb-8f44-170109aa461d.png)
High-contrast mode

The screen mode state (normal or high-contrast mode) is kept inside the Vuex store under the global namespace as a single Boolean value.